### PR TITLE
Mobile Layout Verbesserungen

### DIFF
--- a/src/components/KPIContainer.js
+++ b/src/components/KPIContainer.js
@@ -33,31 +33,31 @@ export default function KPIContainer({totalTours, totalConnections, totalRanges,
 
             <Box sx={{marginTop: '50px'}}>
                 <Grid container>
-                    <Grid item xs={5} sm={2} sx={{marginBottom: "16px"}}>
+                    <Grid item xs={6} sm={2} sx={{marginBottom: "16px"}}>
                         <Box>
                             <Typography variant={"h3"}>{Number(totalTours).toLocaleString()}</Typography>
                             <Typography variant={"text"} color={"#FFFFFF"}>Öffi-Bergtouren</Typography>
                         </Box>
                     </Grid>
-                    <Grid item xs={5} sm={2} sx={{marginBottom: "16px"}}>
+                    <Grid item xs={6} sm={2} sx={{marginBottom: "16px"}}>
                         <Box>
                             <Typography variant={"h3"}>{totalProvider}</Typography>
                             <Typography variant={"text"} color={"#FFFFFF"}>durchsuchte Tourenportale</Typography>
                         </Box>
                     </Grid>
-                    <Grid item xs={5} sm={2} sx={{marginBottom: "16px"}}>
+                    <Grid item xs={6} sm={2} sx={{marginBottom: "16px"}}>
                         <Box>
                             <Typography variant={"h3"}>{totalRanges}</Typography>
                             <Typography variant={"text"} color={"#FFFFFF"}>Wanderregionen</Typography>
                         </Box>
                     </Grid>
-                    <Grid item xs={5} sm={2} sx={{marginBottom: "16px"}}>
+                    <Grid item xs={6} sm={2} sx={{marginBottom: "16px"}}>
                         <Box>
                             <Typography variant={"h3"}>{totalCities}</Typography>
                             <Typography variant={"text"} color={"#FFFFFF"}>verfügbare Heimatbahnhöfe</Typography>
                         </Box>
                     </Grid>
-                    <Grid item xs={5} sm={2} sx={{marginBottom: "16px"}}>
+                    <Grid item xs={6} sm={2} sx={{marginBottom: "16px"}}>
                         <Box>
                             <Typography variant={"h3"}>{Number(totalConnections).toLocaleString()}</Typography>
                             <Typography variant={"text"} color={"#FFFFFF"}>Anzahl Öffi-Verbindungen</Typography>


### PR DESCRIPTION
Hi!

Ich habe eine kleine Verbesserung am mobile Layout der KPI Sektion vorgenommen:
Vorher:  
![image](https://user-images.githubusercontent.com/37791246/222512475-51e640df-10fe-4e73-97f1-56ab9f8bf053.png)

Nacher:  
![image](https://user-images.githubusercontent.com/37791246/222512527-38a30a80-a2ee-43b8-8a55-0e1c8dbbe275.png)

