### PR TITLE
Re-enable matomo integration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import {theme} from "./theme";
 import Start from "./views/Start/Start";
 import ModalRoot from "./components/ModalRoot";
 import {BrowserRouter, Route, Routes, Navigate} from "react-router-dom";
-// import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react'
+import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react'
 import {lazy, Suspense} from "react";
 import CircularProgress from "@mui/material/CircularProgress";
 // import TestComp from '../TestComp';
@@ -17,33 +17,41 @@ const Privacy = lazy(() => import('./views/Pages/Privacy'));
 function App() {
     // const history = createBrowserHistory();
 
-    let siteId = 11;
-    if (process.env.NODE_ENV !== "production") {
-      siteId = 9;
+    let matomoConfig = {
+        siteId: 11,
+        useSecureCookie: false
     }
-    // ******  MATOMO CODE ******
-    // const instance = createInstance({
-    //     urlBase: `${window.location.protocol}//${window.location.host}`,
-    //     siteId: 9,
-    //     trackerUrl: 'https://stats.bahnzumberg.at/matomo.php',
-    //     srcUrl: 'https://stats.bahnzumberg.at/matomo.js', 
-    //     disabled: false, // optional, false by default. Makes all tracking calls no-ops if set to true.
-    //     heartBeat: { // optional, enabled by default
-    //         active: true, // optional, default value: true
-    //         seconds: 10 // optional, default value: `15
-    //     },
-    //     linkTracking: true, // optional, default value: true
-    //     configurations: { // optional, default value: {}
-    //         // any valid matomo configuration, all below are optional
-    //         disableCookies: true,
-    //         setSecureCookie: true,
-    //         setRequestMethod: 'POST'
-    //     }
-    // })
+
+    if (process.env.NODE_ENV === "production") {
+      matomoConfig = {
+          siteId: 9,
+          useSecureCookie: true
+      }
+    }
+
+     const instance = createInstance({
+         urlBase: `${window.location.protocol}//${window.location.host}`,
+         siteId: matomoConfig.siteId,
+         trackerUrl: 'https://stats.bahnzumberg.at/matomo.php',
+         srcUrl: 'https://stats.bahnzumberg.at/matomo.js',
+         disabled: false, // optional, false by default. Makes all tracking calls no-ops if set to true.
+         heartBeat: { // optional, enabled by default
+             active: true, // optional, default value: true
+             seconds: 10 // optional, default value: `15
+         },
+         linkTracking: true, // optional, default value: true
+         configurations: { // optional, default value: {}
+             // any valid matomo configuration, all below are optional
+             disableCookies: true,
+             setSecureCookie: matomoConfig.useSecureCookie,
+             setRequestMethod: 'POST'
+         }
+     })
 
 
-    // <MatomoProvider value={instance}>
+
     return (
+        <MatomoProvider value={instance}>
             <ThemeProvider theme={theme}>
                 <div className="App">
                     <Suspense fallback={<div style={{height: "100%", width: "100%", padding: "20px"}}><CircularProgress /></div>}>
@@ -68,8 +76,8 @@ function App() {
                 </div>
                 <ModalRoot />
             </ThemeProvider>
+        </MatomoProvider>
     );
-    // </MatomoProvider>
 }
 
 export default App;


### PR DESCRIPTION
@martinheppner  ich hätte hier den entsprechenden Matomo Code wieder einkommentiert und die IDs korrigiert.
Gab es einen Grund warum die Integration deaktiviert wurde?

Ich konnte nur überprüfen ob wieder Daten in der Testinstanz landen:
![image](https://user-images.githubusercontent.com/37791246/235211013-7dab83d7-f036-40f3-9075-d5ba0c5a684c.png)
