### PR TITLE
Matomo integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/polyfill": "^7.12.1",
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",
-    "@jonkoops/matomo-tracker-react": "^0.7.0",
+    "@jonkoops/matomo-tracker": "^0.7.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.71",
     "@mui/material": "^5.4.3",

--- a/src/App.js
+++ b/src/App.js
@@ -4,84 +4,62 @@ import ThemeProvider from "@mui/material/styles/ThemeProvider";
 import { theme } from "./theme";
 import Start from "./views/Start/Start";
 import ModalRoot from "./components/ModalRoot";
-import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
-
-import { MatomoProvider, createInstance } from "@jonkoops/matomo-tracker-react";
-
-import { lazy, Suspense } from "react";
+import {Route, Routes, Navigate} from "react-router-dom";
+// import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react';
+import {lazy, Suspense} from "react";
 import CircularProgress from "@mui/material/CircularProgress";
 import DetailReworked from "./views/Main/DetailReworked";
-const Main = lazy(() => import("./views/Main/Main"));
-const About = lazy(() => import("./views/Pages/About"));
-const Impressum = lazy(() => import("./views/Pages/Impressum"));
-const Privacy = lazy(() => import("./views/Pages/Privacy"));
+import {useMatomo} from "./hooks/useMatomo";
+const Main = lazy(() => import('./views/Main/Main'));
+const About = lazy(() => import('./views/Pages/About'));
+const Impressum = lazy(() => import('./views/Pages/Impressum'));
+const Privacy = lazy(() => import('./views/Pages/Privacy'));
 
 function App() {
-	let matomoConfig = {
-		siteId: 11,
-		useSecureCookie: false,
-	};
 
-	if (process.env.NODE_ENV === "production") {
-		matomoConfig = {
-			siteId: 9,
-			useSecureCookie: true,
-		};
-	}
+    let siteId = 11;
+    if (process.env.NODE_ENV === "production") {
+        siteId = 9;
+    }
 
-	const instance = createInstance({
-		urlBase: `${window.location.protocol}//${window.location.host}`,
-		siteId: matomoConfig.siteId,
-		trackerUrl: "https://stats.bahnzumberg.at/matomo.php",
-		srcUrl: "https://stats.bahnzumberg.at/matomo.js",
-		disabled: false, // optional, false by default. Makes all tracking calls no-ops if set to true.
-		heartBeat: {
-			// optional, enabled by default
-			active: true, // optional, default value: true
-			seconds: 10, // optional, default value: `15
-		},
-		linkTracking: true, // optional, default value: true
-		configurations: {
-			// optional, default value: {}
-			// any valid matomo configuration, all below are optional
-			disableCookies: true,
-			setSecureCookie: matomoConfig.useSecureCookie,
-			setRequestMethod: "POST",
-		},
-	});
+    useMatomo({
+        hostConfig: {
+            siteId: siteId,
+            url: "https://stats.bahnzumberg.at"
+        },
+        enableAutoPageTrack: true
+    })
 
-	return (
-		<MatomoProvider value={instance}>
-			<ThemeProvider theme={theme}>
-				<div className="App">
-					<Suspense
-						fallback={
-							<div style={{ height: "100%", width: "100%", padding: "20px" }}>
-								<CircularProgress />
-							</div>
-						}
-					>
-						{/* <BrowserRouter history={history}> */}
-						<BrowserRouter>
-							<Routes>
-								<Route path="/" element={<Start />} />
-								<Route path="/suche" element={<Main />} />
-								<Route path="/about" element={<About />} />
-								<Route path="/tour" element={<DetailReworked />} />
-								<Route path="/imprint" element={<Impressum />} />
-								<Route path="/privacy" element={<Privacy />} />
-								<Route path="/:city" element={<Main />} />
-								{/* <Route path="/cache" element={<TestComp/>}/> */}
 
-								<Route path="*" element={<Navigate to="/" replace />} />
-							</Routes>
-						</BrowserRouter>
-					</Suspense>
-				</div>
-				<ModalRoot />
-			</ThemeProvider>
-		</MatomoProvider>
-	);
+    return (
+        // <MatomoProvider value={instance}>
+            <ThemeProvider theme={theme}>
+                <div className="App">
+                    <Suspense fallback={<div style={{height: "100%", width: "100%", padding: "20px"}}><CircularProgress /></div>}>
+                        {/* <BrowserRouter history={history}> */}
+
+                            <Routes>
+                                <Route path="/" element={<Start/>}/>
+                                <Route path="/suche" element={<Main/>}/>
+                                <Route path="/about" element={<About/>}/>
+                                <Route path="/tour" element={<DetailReworked/>}/>
+                                <Route path="/imprint" element={<Impressum/>}/>
+                                <Route path="/privacy" element={<Privacy/>}/>
+                                <Route path="/:city" element={<Main/>}/>
+                                {/* <Route path="/cache" element={<TestComp/>}/> */}
+
+                                <Route
+                                    path="*"
+                                    element={<Navigate to="/" replace />}
+                                />
+                            </Routes>
+
+                    </Suspense>
+                </div>
+                <ModalRoot />
+            </ThemeProvider>
+        // </MatomoProvider>
+    );
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,6 @@ import { theme } from "./theme";
 import Start from "./views/Start/Start";
 import ModalRoot from "./components/ModalRoot";
 import {Route, Routes, Navigate} from "react-router-dom";
-// import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react';
 import {lazy, Suspense} from "react";
 import CircularProgress from "@mui/material/CircularProgress";
 import DetailReworked from "./views/Main/DetailReworked";
@@ -35,33 +34,29 @@ function App() {
 
 
     return (
-        // <MatomoProvider value={instance}>
-            <ThemeProvider theme={theme}>
-                <div className="App">
-                    <Suspense fallback={<div style={{height: "100%", width: "100%", padding: "20px"}}><CircularProgress /></div>}>
-                        {/* <BrowserRouter history={history}> */}
+        <ThemeProvider theme={theme}>
+            <div className="App">
+                <Suspense fallback={<div style={{height: "100%", width: "100%", padding: "20px"}}><CircularProgress /></div>}>
+                        <Routes>
+                            <Route path="/" element={<Start/>}/>
+                            <Route path="/suche" element={<Main/>}/>
+                            <Route path="/about" element={<About/>}/>
+                            <Route path="/tour" element={<DetailReworked/>}/>
+                            <Route path="/imprint" element={<Impressum/>}/>
+                            <Route path="/privacy" element={<Privacy/>}/>
+                            <Route path="/:city" element={<Main/>}/>
+                            {/* <Route path="/cache" element={<TestComp/>}/> */}
 
-                            <Routes>
-                                <Route path="/" element={<Start/>}/>
-                                <Route path="/suche" element={<Main/>}/>
-                                <Route path="/about" element={<About/>}/>
-                                <Route path="/tour" element={<DetailReworked/>}/>
-                                <Route path="/imprint" element={<Impressum/>}/>
-                                <Route path="/privacy" element={<Privacy/>}/>
-                                <Route path="/:city" element={<Main/>}/>
-                                {/* <Route path="/cache" element={<TestComp/>}/> */}
+                            <Route
+                                path="*"
+                                element={<Navigate to="/" replace />}
+                            />
+                        </Routes>
 
-                                <Route
-                                    path="*"
-                                    element={<Navigate to="/" replace />}
-                                />
-                            </Routes>
-
-                    </Suspense>
-                </div>
-                <ModalRoot />
-            </ThemeProvider>
-        // </MatomoProvider>
+                </Suspense>
+            </div>
+            <ModalRoot />
+        </ThemeProvider>
     );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -17,9 +17,12 @@ const Privacy = lazy(() => import('./views/Pages/Privacy'));
 
 function App() {
 
-    let siteId = 11;
-    if (process.env.NODE_ENV === "production") {
-        siteId = 9;
+    // production matomo ID
+    let siteId = 9;
+
+    // UAT and local development should use matomo test instance
+    if (location.hostname.indexOf('localhost') !== -1 || location.hostname.indexOf('www2.') !== -1) {
+        siteId = 11;
     }
 
     useMatomo({

--- a/src/hooks/useMatomo.js
+++ b/src/hooks/useMatomo.js
@@ -2,6 +2,12 @@ import * as React from 'react';
 import {useLocation} from 'react-router-dom';
 import MatomoTracker from '@jonkoops/matomo-tracker'
 
+/**
+ * A simple hook wrapping the MatomoTracker class provided by @jonkoops/matomo-tracker.
+ * Unfortunately, this package is no longer actively maintained but I believe it is not very likely that the Matomo API will change a lot in the future.
+ * If it is necessary to remove the package only this hook should be affected and there should be no need to change the rest of the codebase.
+ */
+
 export function useMatomo({
                               enableAutoPageTrack,
                               enableLinkTracking,

--- a/src/hooks/useMatomo.js
+++ b/src/hooks/useMatomo.js
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {useLocation} from 'react-router-dom';
+import MatomoTracker from '@jonkoops/matomo-tracker'
+
+export function useMatomo({
+                              enableAutoPageTrack,
+                              enableLinkTracking,
+                              hostConfig: {
+                                  url,
+                                  siteId
+                              }
+                          }) {
+
+    const tracker = new MatomoTracker({
+        urlBase: url,
+        siteId,
+        linkTracking: enableLinkTracking,
+        configurations: {
+            disableCookies: true
+        }
+    })
+    if (enableAutoPageTrack) {
+        const location = useLocation();
+        React.useEffect(() => {
+            tracker.trackPageView();
+        }, [location.pathname])
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import rootReducer from "./rootReducer";
 import { Helmet } from 'react-helmet';
 import { Provider } from 'react-redux';
 import "./translations/i18n";
+import {BrowserRouter} from "react-router-dom";
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 export const store = createStore(rootReducer, composeEnhancers(
@@ -45,7 +46,9 @@ root.render(
             />
         </Helmet>
       </div>
-      <App />
+        <BrowserRouter>
+            <App />
+        </BrowserRouter>
     </Provider>
   </React.StrictMode>
 );

--- a/src/utils/globals.js
+++ b/src/utils/globals.js
@@ -161,27 +161,6 @@ export const getTopLevelDomain = () => {
     return host.substring(host.length-2).toUpperCase();
 }
 
-export const myTrackPageView = (pageTitle, trackPageView, city) => {
-    let dimensions = [
-        {
-            id: 1,
-            value: getTopLevelDomain(),
-        }
-    ];
-
-    if(!!city){
-        dimensions.push({
-            id: 2,
-            value: city
-        })
-    }
-
-    trackPageView({
-        documentTitle: pageTitle,
-        customDimensions: dimensions
-    })
-}
-
 export const parseTourConnectionDescription = (connection, field = "connection_description_detail") => {
     if(!!connection){
         return connection[field].split('\n');

--- a/src/views/Main/Main.js
+++ b/src/views/Main/Main.js
@@ -17,11 +17,9 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import {
 	getFilterFromParams,
-	getFilterProp,
-	// myTrackPageView,
+	getFilterProp
 } from "../../utils/globals";
 import CircularProgress from "@mui/material/CircularProgress";
-// import {useMatomo} from "@datapunt/matomo-tracker-react";
 // import {useBackListener} from "../../utils/backListener";
 import TourMapContainer from "../../components/Map/TourMapContainer";
 import * as PropTypes from "prop-types";
@@ -132,12 +130,6 @@ export function Main({
 	// useBackListener(({ location }) => {
 	//     navigate('/');
 	// });
-
-	//Matomo related
-	// useEffect(() => {
-	//     const city = searchParams.get('city');
-	//     myTrackPageView("Main", trackPageView, city);
-	// }, [])
 
 	//describe:
 	// this useEffect sets up the initial state for the component by loading cities and ranges data and setting up search param in local state (searchParams)

--- a/src/views/Start/Start.js
+++ b/src/views/Start/Start.js
@@ -15,8 +15,6 @@ import { connect } from "react-redux";
 import Footer from "../../components/Footer/Footer";
 import { useSearchParams } from "react-router-dom";
 import { useNavigate } from "react-router";
-import { useMatomo } from "@jonkoops/matomo-tracker-react";
-import { myTrackPageView } from "../../utils/globals";
 import FooterLinks from "../../components/Footer/FooterLinks";
 import { useTranslation } from "react-i18next";
 import {
@@ -76,18 +74,10 @@ function Start({
 	loadRanges,
 	allRanges,
 }) {
-	const { trackPageView } = useMatomo();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const navigate = useNavigate();
 	const [showMobileMenu, setShowMobileMenu] = React.useState(false);
 	const { t, i18n } = useTranslation();
-	// description
-	// makes use of the Matomo Tracker Hook (useMatomo) to track page views. The function myTrackPageView is used to track the current page view.
-	useEffect(() => {
-		const city = searchParams.get("city");
-		// console.log('city is ' + city);
-		myTrackPageView("Start", trackPageView, city);
-	}, []);
 
 	// description
 	// This useEffect hook is used to execute some code in response to a change in the component's state or props. It is executed whenever the component is updated or rendered. The hook runs the loadAllCities function which is an action creator from the file cityActions.js.


### PR DESCRIPTION
Hallo!
Wie in #4 besprochen habe ich nun auch die Prüfung auf die Umgebung umgebaut (keine Prüfung auf die Umgebungsvariable mehr, sondern auf den Hostname).

Um den useEffect zu verwenden, musst ich den `<BrowserRouter>` Tag auf eine höhere Ebene verlagern (in das `index.js` File). 
Leider gibt es kein gewartetes Matomo NPM Package mehr, aber ich denke die Matomo API sollte recht stabil sein und falls diesbezüglich Änderungen notwendig wären müsste nur `useMatomo.js` File angepasst werden.  

Mit der geänderten Prüfung sollte auch einem Test auf der UAT Umgebung nichts mehr im Weg stehen! 
Wäre super wenn noch jemand darüber testen könnte, der vertrauter mit der Applikation ist!