### PR TITLE
Load optimizer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,9 @@ import { getTopLevelDomain } from "./utils/globals";
 import Start from "./views/Start/Start";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import Main from "./views/Main/Main";
 
+// Importiere DetailReworked und Main jetzt dynamisch
+const Main = lazy(() => import("./views/Main/Main"));
 const Impressum = lazy(() => import("./views/Pages/Impressum"));
 const Privacy = lazy(() => import("./views/Pages/Privacy"));
 const DetailReworked = lazy(() => import("./views/Main/DetailReworked"));
@@ -66,9 +67,30 @@ function App() {
           <Routes>
             <Route path="/" element={<Start />} />
             <Route path="/total" element={<Start />} />
-            <Route path="/imprint" element={<Impressum />} />
-            <Route path="/privacy" element={<Privacy />} />
-            <Route path="/search" element={<Main />} />
+            <Route
+              path="/imprint"
+              element={
+                <Suspense fallback={<div>Loading…</div>}>
+                  <Impressum />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/privacy"
+              element={
+                <Suspense fallback={<div>Loading…</div>}>
+                  <Privacy />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/search"
+              element={
+                <Suspense fallback={<div>Loading…</div>}>
+                  <Main />
+                </Suspense>
+              }
+            />
             <Route
               path="/tour/:idOne/:cityOne?"
               element={
@@ -85,7 +107,14 @@ function App() {
                 </Suspense>
               }
             />
-            <Route path="/:city" element={<Main />} />
+            <Route
+              path="/:city"
+              element={
+                <Suspense fallback={<div>Loading…</div>}>
+                  <Main />
+                </Suspense>
+              }
+            />
 
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/views/Main/Main.tsx
+++ b/src/views/Main/Main.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, lazy, Suspense } from "react";
 import Box from "@mui/material/Box";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-import TourMapContainer from "../../components/Map/TourMapContainer";
-import { Typography } from "@mui/material";
+// Importiere die Karten-Komponente jetzt dynamisch
+const TourMapContainer = lazy(() => import("../../components/Map/TourMapContainer"));
+import { Typography, Skeleton } from "@mui/material";
 import DomainMenu from "../../components/DomainMenu";
 import LanguageMenu from "../../components/LanguageMenu";
 import { useTranslation } from "react-i18next";
@@ -291,7 +292,9 @@ export default function Main() {
 
       {showMap && (
         <Box className={"map-container"}>
-          <TourMapContainer markers={loadedTours?.markers || []} />
+          <Suspense fallback={<Skeleton variant="rectangular" width="100%" height="100%" />}>
+            <TourMapContainer markers={loadedTours?.markers || []} />
+          </Suspense>
         </Box>
       )}
       {totalToursHeader()}

--- a/src/views/Start/Start.tsx
+++ b/src/views/Start/Start.tsx
@@ -1,7 +1,7 @@
 import { Box, Skeleton, Typography } from "@mui/material";
 import React, { lazy, Suspense, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router";
+import { Link } from "react-router-dom";
 import { useIsMobile } from "../../utils/globals";
 import {
   usePageHeader,
@@ -18,12 +18,10 @@ import { useSelector } from "react-redux";
 import SearchParamSync from "../../components/SearchParamSync";
 import { useAppDispatch } from "../../hooks";
 import { mapUpdated } from "../../features/searchSlice";
+import RangeCardContainer from "../../components/RangeCardContainer";
 
-const RangeCardContainer = lazy(
-  () => import("../../components/RangeCardContainer"),
-);
+// Dynamische Imports für nicht-kritische Komponenten
 const KPIContainer = lazy(() => import("../../components/KPIContainer"));
-
 const MapBtn = lazy(() => import("../../components/Search/MapBtn"));
 const Footer = lazy(() => import("../../components/Footer/Footer"));
 
@@ -182,6 +180,7 @@ export default function Start() {
                 >
                   {getRangeText()}
                 </Typography>
+                {/* RangeCardContainer ist wieder statisch importiert */}
                 <RangeCardContainer ranges={loadedTours.ranges} />
               </Box>
               <Box sx={{ marginTop: "80px" }}>


### PR DESCRIPTION
Please check this changes. The idea was to remove the blocking of the initial rendering, by changing the way we handle css and to create more bundles, to reduce loading times. The language json files are not exzessiv large, but in 99% of the cases only 1 out of 5 is needed - so we load only this.


Edit by @kohloderso
The following types of changes have been implemented (I took the liberty of rearranging the commits into clear packages with `git rebase`):
-   Merge index.css into App.css - Clear and unproblematic. Definitely an improvement! :heavy_check_mark: 
- Apply optimizations in prod bundler - can't say yet if these are good changes, but everything looked good when I tested, yay :heavy_check_mark: 
- load only required language json - good idea, I fixed a tiny problem with the path to the language files on urls like http://localhost:3000/tour/115948/st-johann-in-tirol :heavy_check_mark: 
- Use dynamic imports - after adding missing style import, this looks great :heavy_check_mark:  