### PR TITLE
Feat/742 remove filter bounds url

### DIFF
--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -119,28 +119,40 @@ export default function Filter({ showFilter, setShowFilter }: FilterProps) {
         hasInitialized.current = true;
         setTempFilter({ ...defaultFilterValues, ...storedFilter });
       } else {
-        // Subsequent re-fetches: preserve user's in-progress selections, only update bounds/defaults.
-        // Intersect array selections with available options to drop stale values (e.g. a region
-        // that's no longer reachable after travel time is reduced).
+        // Re-fetch response arrived. Two possible causes:
+        // 1. User changed a selection inside the open dialog → debounce triggered a re-fetch.
+        //    Preserve in-progress selections (use prev) and intersect arrays with available options.
+        // 2. storedFilter changed externally while dialog is closed (e.g. chip removal).
+        //    Re-sync from storedFilter so the stale prev is discarded.
         setTempFilter((prev) => {
+          const base = showFilter ? prev : storedFilter;
           const intersect = <T,>(
-            prevArr: T[] | undefined,
+            arr: T[] | undefined,
             available: T[] | undefined,
           ): T[] | undefined => {
-            if (!prevArr) return prevArr;
-            if (!available) return prevArr;
-            return prevArr.filter((v) => available.includes(v));
+            if (!arr) return arr;
+            if (!available) return arr;
+            return arr.filter((v) => available.includes(v));
           };
           return {
             ...defaultFilterValues,
-            ...prev,
-            ranges: intersect(prev.ranges, fetchedFilter?.ranges),
-            types: intersect(prev.types, fetchedFilter?.types),
-            languages: intersect(prev.languages, fetchedFilter?.languages),
-            countries: intersect(prev.countries, fetchedFilter?.countries),
-            providers: intersect(prev.providers, fetchedFilter?.providers),
+            ...base,
+            ranges: intersect(base.ranges ?? [], fetchedFilter?.ranges),
+            types: intersect(base.types ?? [], fetchedFilter?.types),
+            languages: intersect(
+              base.languages ?? [],
+              fetchedFilter?.languages,
+            ),
+            countries: intersect(
+              base.countries ?? [],
+              fetchedFilter?.countries,
+            ),
+            providers: intersect(
+              base.providers ?? [],
+              fetchedFilter?.providers,
+            ),
             difficulties: intersect(
-              prev.difficulties,
+              base.difficulties ?? [],
               fetchedFilter?.difficulties,
             ),
           };

--- a/src/components/SearchParamSync.ts
+++ b/src/components/SearchParamSync.ts
@@ -4,7 +4,6 @@ import { RootState } from "..";
 import { useSelector } from "react-redux";
 import { useAppDispatch } from "../hooks";
 import {
-  boundsUpdated,
   citySlugUpdated,
   cityUpdated,
   mapUpdated,
@@ -19,6 +18,33 @@ import {
 } from "../features/apiSlice";
 import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
 import { filterUpdated } from "../features/filterSlice";
+import { FilterObject } from "../models/Filter";
+import { getDefaultFilterValues } from "./Filter/utils";
+
+const SCALAR_FILTER_KEYS = [
+  "singleDayTour",
+  "multipleDayTour",
+  "summerSeason",
+  "winterSeason",
+  "traverse",
+  "minAscent",
+  "maxAscent",
+  "minDescent",
+  "maxDescent",
+  "minTransportDuration",
+  "maxTransportDuration",
+  "minDistance",
+  "maxDistance",
+] as const;
+
+const ARRAY_FILTER_KEYS = [
+  "ranges",
+  "types",
+  "languages",
+  "difficulties",
+  "providers",
+  "countries",
+] as const;
 
 /**
  * Keeps query parameters in sync with the Redux store.
@@ -71,8 +97,7 @@ export default function SearchParamSync({
 
   useEffect(() => {
     const newParams = new URLSearchParams();
-    // lang is managed by LanguageParamSync — use Redux value when available,
-    // fall back to URL to avoid wiping it during initialisation (when language is null)
+    // use Redux value when available, fall back to URL during initialisation (when language is null)
     updateParam(newParams, "lang", search.language ?? params.get("lang"));
     updateParam(newParams, "city", search.citySlug);
     updateParam(newParams, "p", search.provider);
@@ -91,31 +116,35 @@ export default function SearchParamSync({
       "search_type",
       isSearchResultsPage ? search.searchWithType?.type : null,
     );
-    if (!search.geolocation) {
+    if (isSearchResultsPage && search.geolocation) {
+      updateParam(newParams, "lat", String(search.geolocation.lat));
+      updateParam(newParams, "lng", String(search.geolocation.lng));
       updateParam(
         newParams,
-        "bounds",
-        isSearchResultsPage && search.bounds
-          ? JSON.stringify(search.bounds)
-          : null,
+        "radius",
+        String(search.geolocation.radius ?? 100),
       );
     } else {
-      updateParam(newParams, "bounds", null);
+      updateParam(newParams, "lat", null);
+      updateParam(newParams, "lng", null);
+      updateParam(newParams, "radius", null);
     }
-    updateParam(
-      newParams,
-      "geolocation",
-      isSearchResultsPage && search.geolocation
-        ? JSON.stringify(search.geolocation)
-        : null,
-    );
-    updateParam(
-      newParams,
-      "filter",
-      isSearchResultsPage && Object.keys(filter).length > 0
-        ? JSON.stringify(filter)
-        : null,
-    );
+
+    if (isSearchResultsPage) {
+      const defaults = getDefaultFilterValues();
+      for (const key of SCALAR_FILTER_KEYS) {
+        const val = filter[key];
+        if (val !== undefined && val !== defaults[key]) {
+          newParams.set(key, String(val));
+        }
+      }
+      for (const key of ARRAY_FILTER_KEYS) {
+        const arr = filter[key];
+        if (arr?.length) {
+          newParams.set(key, arr.map(String).join("|"));
+        }
+      }
+    }
     setParams(newParams, { replace: true });
   }, [search, filter]);
 
@@ -151,45 +180,45 @@ export default function SearchParamSync({
         dispatch(mapUpdated(false));
       }
 
-      // geolocation comes either as "geolocation" or as separate "lat", "lng" and "radius"
       const lat = params.get("lat");
       const lng = params.get("lng");
       const radius = params.get("radius");
-      const geolocation = params.get("geolocation");
-      if (geolocation || (lat && lng)) {
-        const parsedLocation = geolocation
-          ? JSON.parse(geolocation)
-          : { lat: lat, lng: lng, radius: radius };
-        if (!parsedLocation.radius) {
-          parsedLocation.radius = 100;
-        }
-        dispatch(geolocationUpdated(parsedLocation));
+      if (lat && lng) {
+        dispatch(
+          geolocationUpdated({
+            lat: Number(lat),
+            lng: Number(lng),
+            radius: radius ? Number(radius) : 100,
+          }),
+        );
       } else {
         dispatch(geolocationUpdated(null));
       }
 
-      const bounds = params.get("bounds");
-      if (!geolocation && bounds) {
-        const parsedBounds = JSON.parse(bounds);
-        dispatch(boundsUpdated(parsedBounds));
-      } else {
-        dispatch(boundsUpdated(null));
+      const filterObject: FilterObject = {};
+      for (const key of SCALAR_FILTER_KEYS) {
+        const value = params.get(key);
+        if (value === "true") (filterObject[key] as boolean) = true;
+        else if (value === "false") (filterObject[key] as boolean) = false;
+        else if (value !== null && !isNaN(Number(value)))
+          (filterObject[key] as number) = Number(value);
       }
-
-      const filterParam = params.get("filter");
-      let parsedFilter = {};
-      if (filterParam) {
-        parsedFilter = JSON.parse(filterParam);
-        dispatch(filterUpdated(parsedFilter));
-      } else {
-        dispatch(filterUpdated({}));
+      for (const key of ARRAY_FILTER_KEYS) {
+        const raw = params.get(key);
+        if (raw) {
+          const values = raw.split("|").filter(Boolean);
+          if (values.length) {
+            (filterObject[key] as string[] | number[]) =
+              key === "difficulties" ? values.map(Number) : values;
+          }
+        }
       }
-
-      // if range is set like this -> update range in filter
+      // ?range=slug from range-card navigation
       const range = params.get("range");
-      if (range) {
-        dispatch(filterUpdated({ ...parsedFilter, ranges: [range] }));
+      if (range && !filterObject.ranges?.length) {
+        filterObject.ranges = [range];
       }
+      dispatch(filterUpdated(filterObject));
     }
   }, []);
 


### PR DESCRIPTION
While I wrote the most code, I used claude for reviewing and making some other changes;

What was done?
URL params were changed to store only data that is needed instead of storing entire filter obejct. For example currently when user de-selects one region, we store rest of the region (about 23) in URL. This makes it pretty long. Now we store only the one region that user actively de-selected; this applies to other filters, with more than one possible values.

I choose to use duplicate param to store more than one value each filter because it's the simplest; we don't need to do any parsing to get the values. URL object supports getting all the values for one key.

Aftter & Before:
http://localhost:3000/search?city=amstetten&lang=de&ranges=Goldberggruppe&types=Wandern



https://www.zuugle.at/search?city=baden&lang=de&filter=%7B%22ranges%22%3A%5B%22Alpenvorland%22%2C%22Ankogelgruppe%22%2C%22Berchtesgadener+Alpen%22%2C%22B%C3%B6hmerwald%22%2C%22Brandenberger+Alpen%22%2C%22Chiemgauer+Alpen%22%2C%22Dachsteingebirge%22%2C%22Deutschland%22%2C%22Ennstaler+Alpen%22%2C%22Gailtaler+Alpen%22%2C%22Goldberggruppe%22%2C%22Gurktaler+Alpen%2C+Nockberge%22%2C%22Gutensteiner+Alpen%22%2C%22Hausruck%22%2C%22Hochschwabgruppe%22%2C%22Kaisergebirge%22%2C%22Karavanke+%2F+Karawanken%22%2C%22Karpaten%22%2C%22Karwendel%22%2C%22Kitzb%C3%BCheler+Alpen%22%2C%22Kreuzeckgruppe%22%2C%22Lavanttaler+Alpen%22%2C%22Loferer+und+Leoganger+Steinberge%22%2C%22M%C3%BChlviertel%22%2C%22M%C3%BCrzsteger+Alpen%22%2C%22Nieder%C3%B6sterreich%22%2C%22Ober%C3%B6sterreich%22%2C%22Ober%C3%B6sterreichische+Voralpen%22%2C%22%C3%96tztaler+Alpen%22%2C%22Randgebirge+%C3%B6stlich+der+Mur%22%2C%22Rax-Schneeberg-Gruppe%22%2C%22Rottenmanner+und+W%C3%B6lzer+Tauern%22%2C%22Salzburg%22%2C%22Salzburger+Schieferalpen%22%2C%22Salzkammergut-Berge%22%2C%22Schladminger+Tauern%22%2C%22Schobergruppe%22%2C%22Seckauer+Tauern%22%2C%22Steiermark%22%2C%22Stubaier+Alpen%22%2C%22Tirol%22%2C%22Totes+Gebirge%22%2C%22Tschechien%22%2C%22T%C3%BCrnitzer+Alpen%22%2C%22Tuxer+Alpen%22%2C%22Waldviertel%22%2C%22Wetterstein-+%26+Mieminger+Gebirge%22%2C%22Wien%22%2C%22Wienerwald%22%2C%22Ybbstaler+Alpen%22%2C%22Zillertaler+Alpen%22%5D%2C%22types%22%3A%5B%22Bike+%26+Hike%22%2C%22Hochtour%22%2C%22Klettern%22%2C%22Klettersteig%22%2C%22Langlaufen%22%2C%22Rodeln%22%2C%22Schneeschuh%22%2C%22Skitour%22%2C%22Wandern%22%5D%7D
