### PR TITLE
fix: consistent tour count on start page (#838)

### DIFF
--- a/src/views/Start/Header.tsx
+++ b/src/views/Start/Header.tsx
@@ -56,7 +56,7 @@ export default function Header({ totals, isLoading }: HeaderProps) {
 
             <Box className="header-text">
               <Typography variant="h1" sx={{ height: "162px" }}>
-                {totals?.tours_country.toLocaleString()}{" "}
+                {totals?.tours_country?.toLocaleString()}{" "}
                 {t("start.tourenanzahl_untertitel")}
               </Typography>
             </Box>

--- a/src/views/Start/Start.tsx
+++ b/src/views/Start/Start.tsx
@@ -164,7 +164,7 @@ export default function Start() {
                   </Box>
                   <Box sx={{ marginTop: "80px" }}>
                     <KPIContainer
-                      totalTours={totals?.total_tours || 0}
+                      totalTours={totals?.tours_country || 0}
                       totalConnections={totals?.total_connections || 0}
                       totalCities={totals?.total_cities || 0}
                       totalProvider={totals?.total_provider || 0}


### PR DESCRIPTION
## Summary
(Vibe coded).
- The KPI section at the bottom of the start page was showing `total_tours` (global count across all countries, e.g. 30,505) while the header at the top showed `tours_country` (domain-specific count, e.g. 21,961 for zuugle.at). This made the same page display two different numbers for what looks like the same thing.
- Fixed by using `tours_country` for the KPI `totalTours` prop, making it consistent with the header.
- Also added a null guard (`tours_country?.toLocaleString()`) in the header to prevent a potential runtime error if `tours_country` is undefined.

## Test plan

- [ ] Open the start page on zuugle.at (or local dev with Austrian data) — header and KPI should show the same tour count
- [ ] Open the start page on zuugle.fr — header and KPI should show the same (France-specific) count
- [ ] No TypeScript errors (`npm run build`)

Closes #838

---
🤖 Written by [Claude Code](https://claude.com/claude-code)