### PR TITLE
UI improvements: sticky map, footer layout, search button, stop hover…

### DIFF
--- a/src/components/ConnectionSearch/ConnectionResults.tsx
+++ b/src/components/ConnectionSearch/ConnectionResults.tsx
@@ -37,7 +37,9 @@ import { Tour } from "../../models/Tour";
 
 interface ConnectionElement {
   from_location: string;
+  from_location_coordinates?: { lat: number; lon: number };
   to_location: string;
+  to_location_coordinates?: { lat: number; lon: number };
   departure_time: string;
   arrival_time: string;
   type: string; // "JNY" = journey, "TRSF" = transfer
@@ -100,6 +102,7 @@ interface ConnectionResultsProps {
     fromStart?: string;
     fromEnd?: string;
   } | null;
+  onStopHover?: (coords: { lat: number; lon: number } | null) => void;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────
@@ -360,12 +363,17 @@ function ConnectionTabs({
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Auto-scroll selected tab into view
+  // Auto-scroll selected tab into view (horizontal only, no page scroll)
   useEffect(() => {
     const idx = connections.findIndex((c) => c.connection_id === selectedId);
     if (idx >= 0 && scrollRef.current) {
       const child = scrollRef.current.children[idx] as HTMLElement;
-      child?.scrollIntoView({ behavior: "smooth", inline: "center" });
+      if (child) {
+        const container = scrollRef.current;
+        const scrollLeft =
+          child.offsetLeft - container.offsetWidth / 2 + child.offsetWidth / 2;
+        container.scrollTo({ left: scrollLeft, behavior: "smooth" });
+      }
     }
   }, [selectedId, connections]);
 
@@ -461,11 +469,13 @@ function ConnectionTimeline({
   coordinateReplacements,
   lang,
   t,
+  onStopHover,
 }: {
   elements: ConnectionElement[];
   coordinateReplacements?: CoordinateReplacement;
   lang: string;
   t: (key: string) => string;
+  onStopHover?: (coords: { lat: number; lon: number } | null) => void;
 }) {
   const firstEl = elements[0];
   const lastEl = elements[elements.length - 1];
@@ -475,7 +485,7 @@ function ConnectionTimeline({
     lastEl && (lastEl.type === "WALK" || lastEl.type === "TRSF");
 
   return (
-    <Box sx={{ mt: "12px" }}>
+    <Box sx={{ mt: "20px", mb: "20px" }}>
       {/* Show first station if the first element is a WALK/TRSF */}
       {firstIsNonJourney && (
         <Box sx={{ display: "flex", alignItems: "center" }}>
@@ -509,7 +519,18 @@ function ConnectionTimeline({
           >
             {formatTime(firstEl.departure_time)}
           </Typography>
-          <Typography sx={{ fontSize: "16px", fontWeight: 600 }}>
+          <Typography
+            sx={{
+              fontSize: "16px",
+              fontWeight: 600,
+              cursor: firstEl.from_location_coordinates ? "pointer" : undefined,
+            }}
+            onMouseEnter={() =>
+              firstEl.from_location_coordinates &&
+              onStopHover?.(firstEl.from_location_coordinates)
+            }
+            onMouseLeave={() => onStopHover?.(null)}
+          >
             {resolveLocationName(firstEl.from_location, coordinateReplacements)}
           </Typography>
         </Box>
@@ -627,7 +648,18 @@ function ConnectionTimeline({
               >
                 {formatTime(el.departure_time)}
               </Typography>
-              <Typography sx={{ fontSize: "16px", fontWeight: 600 }}>
+              <Typography
+                sx={{
+                  fontSize: "16px",
+                  fontWeight: 600,
+                  cursor: el.from_location_coordinates ? "pointer" : undefined,
+                }}
+                onMouseEnter={() =>
+                  el.from_location_coordinates &&
+                  onStopHover?.(el.from_location_coordinates)
+                }
+                onMouseLeave={() => onStopHover?.(null)}
+              >
                 {resolveLocationName(el.from_location, coordinateReplacements)}
               </Typography>
             </Box>
@@ -712,7 +744,18 @@ function ConnectionTimeline({
                 >
                   {formatTime(el.arrival_time)}
                 </Typography>
-                <Typography sx={{ fontSize: "16px", fontWeight: 600 }}>
+                <Typography
+                  sx={{
+                    fontSize: "16px",
+                    fontWeight: 600,
+                    cursor: el.to_location_coordinates ? "pointer" : undefined,
+                  }}
+                  onMouseEnter={() =>
+                    el.to_location_coordinates &&
+                    onStopHover?.(el.to_location_coordinates)
+                  }
+                  onMouseLeave={() => onStopHover?.(null)}
+                >
                   {resolveLocationName(el.to_location, coordinateReplacements)}
                 </Typography>
               </Box>
@@ -754,7 +797,18 @@ function ConnectionTimeline({
           >
             {formatTime(lastEl.arrival_time)}
           </Typography>
-          <Typography sx={{ fontSize: "16px", fontWeight: 600 }}>
+          <Typography
+            sx={{
+              fontSize: "16px",
+              fontWeight: 600,
+              cursor: lastEl.to_location_coordinates ? "pointer" : undefined,
+            }}
+            onMouseEnter={() =>
+              lastEl.to_location_coordinates &&
+              onStopHover?.(lastEl.to_location_coordinates)
+            }
+            onMouseLeave={() => onStopHover?.(null)}
+          >
             {resolveLocationName(lastEl.to_location, coordinateReplacements)}
           </Typography>
         </Box>
@@ -849,6 +903,7 @@ export default function ConnectionResults({
   searchDate,
   activityDurationMinutes,
   shareTimeHints,
+  onStopHover,
 }: ConnectionResultsProps) {
   const { t, i18n } = useTranslation();
   const { connections, activity } = data;
@@ -1125,6 +1180,7 @@ export default function ConnectionResults({
               coordinateReplacements={coordinateReplacements}
               lang={i18n.language}
               t={t}
+              onStopHover={onStopHover}
             />
           )}
         </Box>
@@ -1277,6 +1333,7 @@ export default function ConnectionResults({
               coordinateReplacements={coordinateReplacements}
               lang={i18n.language}
               t={t}
+              onStopHover={onStopHover}
             />
           )}
 

--- a/src/components/ConnectionSearch/ConnectionSearchForm.tsx
+++ b/src/components/ConnectionSearch/ConnectionSearchForm.tsx
@@ -10,6 +10,7 @@ import Autocomplete from "@mui/material/Autocomplete";
 import CircularProgress from "@mui/material/CircularProgress";
 import InputAdornment from "@mui/material/InputAdornment";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
+import DirectionsTransitIcon from "@mui/icons-material/DirectionsTransit";
 import { useTranslation } from "react-i18next";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
@@ -36,10 +37,12 @@ import ConnectionResults, { ConnectionsResultData } from "./ConnectionResults";
 
 interface ConnectionSearchFormProps {
   tour: Tour;
+  onStopHover?: (coords: { lat: number; lon: number } | null) => void;
 }
 
 export default function ConnectionSearchForm({
   tour,
+  onStopHover,
 }: ConnectionSearchFormProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language.substring(0, 2);
@@ -92,7 +95,6 @@ export default function ConnectionSearchForm({
   const [connectionsResult, setConnectionsResult] =
     useState<ConnectionsResultData | null>(null);
   const [searchError, setSearchError] = useState<string | null>(null);
-  const scrollAfterResultRef = useRef(false);
 
   // Share restore state
   const [searchParams] = useSearchParams();
@@ -372,17 +374,6 @@ export default function ConnectionSearchForm({
 
       setConnectionsResult(data);
 
-      // Scroll to Anreise header after manual search
-      if (scrollAfterResultRef.current) {
-        scrollAfterResultRef.current = false;
-        setTimeout(() => {
-          document.getElementById("anreise-header")?.scrollIntoView({
-            behavior: "smooth",
-            block: "start",
-          });
-        }, 150);
-      }
-
       // Update city in Redux and URL when GeoJSON lookup found a city
       if (departureLocation?.citySlug && departureLocation?.cityName) {
         const cityObj = {
@@ -502,9 +493,15 @@ export default function ConnectionSearchForm({
               {...props}
               key={`${option.lat}-${option.lon}-${option.displayName}`}
             >
-              <LocationOnIcon
-                sx={{ color: "#8B8B8B", mr: 1, fontSize: "18px" }}
-              />
+              {option.locationType === "station" ? (
+                <DirectionsTransitIcon
+                  sx={{ color: "var(--bzb-bahnblau)", mr: 1, fontSize: "18px" }}
+                />
+              ) : (
+                <LocationOnIcon
+                  sx={{ color: "var(--bzb-akelei)", mr: 1, fontSize: "18px" }}
+                />
+              )}
               <Typography sx={{ fontSize: "14px" }}>
                 {option.displayName}
               </Typography>
@@ -521,7 +518,20 @@ export default function ConnectionSearchForm({
                   ...params.slotProps?.input,
                   startAdornment: (
                     <InputAdornment position="start">
-                      <LocationOnIcon sx={{ color: "#8B8B8B" }} />
+                      <LocationOnIcon
+                        sx={{
+                          color: "var(--bzb-akelei)",
+                          ...(!departureLocation && {
+                            "@keyframes bounce": {
+                              "0%, 100%": { transform: "translateY(0)" },
+                              "30%": { transform: "translateY(-4px)" },
+                              "50%": { transform: "translateY(0)" },
+                              "70%": { transform: "translateY(-2px)" },
+                            },
+                            animation: "bounce 1.5s ease infinite",
+                          }),
+                        }}
+                      />
                     </InputAdornment>
                   ),
                   endAdornment: (
@@ -663,9 +673,9 @@ export default function ConnectionSearchForm({
                 <Button
                   variant="contained"
                   disabled={!canSearch || isSearching}
-                  onClick={() => {
-                    scrollAfterResultRef.current = true;
+                  onClick={(e) => {
                     handleSearch();
+                    (e.currentTarget as HTMLButtonElement).blur();
                   }}
                   sx={{
                     flex: "0 0 auto",
@@ -681,6 +691,9 @@ export default function ConnectionSearchForm({
                     whiteSpace: "nowrap",
                     "&:hover": {
                       bgcolor: isSearching ? "var(--bzb-bahnblau)" : "#5a1d61",
+                    },
+                    "&:focus, &:focus-visible": {
+                      bgcolor: "var(--bzb-akelei)",
                     },
                     "&.Mui-disabled": { bgcolor: "#ccc", color: "#888" },
                   }}
@@ -764,17 +777,16 @@ export default function ConnectionSearchForm({
                 </Box>
               </Box>
 
-              {/* Search button: mx auto → right when same line, centered when wrapped */}
+              {/* Search button: left-aligned when wrapped on mobile */}
               <Button
                 variant="contained"
                 disabled={!canSearch || isSearching}
-                onClick={() => {
-                  scrollAfterResultRef.current = true;
+                onClick={(e) => {
                   handleSearch();
+                  (e.currentTarget as HTMLButtonElement).blur();
                 }}
                 sx={{
                   flex: "0 0 auto",
-                  mx: "auto",
                   alignSelf: "flex-end",
                   bgcolor: isSearching
                     ? "var(--bzb-bahnblau)"
@@ -788,6 +800,9 @@ export default function ConnectionSearchForm({
                   whiteSpace: "nowrap",
                   "&:hover": {
                     bgcolor: isSearching ? "var(--bzb-bahnblau)" : "#5a1d61",
+                  },
+                  "&:focus, &:focus-visible": {
+                    bgcolor: "var(--bzb-akelei)",
                   },
                   "&.Mui-disabled": { bgcolor: "#ccc", color: "#888" },
                 }}
@@ -848,6 +863,7 @@ export default function ConnectionSearchForm({
             searchDate={getSelectedDate()}
             activityDurationMinutes={activityDurationMinutes}
             shareTimeHints={shareTimeHints}
+            onStopHover={onStopHover}
           />
         )}
       </Box>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -84,90 +84,80 @@ export default function Footer() {
               md: 10,
             }}
           >
-            <Grid container spacing={2}>
-              <Grid
-                style={{ maxWidth: "45px" }}
-                className={"footer-logo"}
-                size={{
-                  xs: "auto",
-                  md: 2,
-                }}
+            <Box
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                alignItems: "center",
+                gap: { xs: "8px 16px", md: "0px" },
+              }}
+            >
+              <a
+                href="https://verein.bahn-zum-berg.at/"
+                target="_blank"
+                rel="noreferrer"
+                style={{ display: "flex", alignItems: "center" }}
               >
-                <a
-                  href="https://verein.bahn-zum-berg.at/"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <img
-                    src={`https://cdn.zuugle.at/img/bahnzumberg_logo_blue.svg`}
-                    width={"45px"}
-                    height={"auto"}
-                    alt="Bahn zum Berg"
-                    loading="lazy"
-                  />
-                </a>
-              </Grid>
-              <Grid
-                size={{
-                  xs: "grow",
-                  md: 3,
-                }}
+                <img
+                  src={`https://cdn.zuugle.at/img/bahnzumberg_logo_blue.svg`}
+                  width={"45px"}
+                  height={"auto"}
+                  alt="Bahn zum Berg"
+                  loading="lazy"
+                />
+              </a>
+              <a
+                href="https://verein.bahn-zum-berg.at"
+                target="_blank"
+                rel="noreferrer"
+                style={{ textDecoration: "none", color: "inherit" }}
               >
-                <a
-                  href="https://verein.bahn-zum-berg.at"
-                  target="_blank"
-                  rel="noreferrer"
-                  style={{ textDecoration: "none", color: "inherit" }}
+                <Typography
+                  sx={{
+                    marginLeft: "10px",
+                    textDecoration: "underline",
+                    whiteSpace: "nowrap",
+                  }}
+                  className={"cursor-link"}
                 >
-                  <Typography
-                    sx={{
-                      marginLeft: "10px",
-                      textDecoration: "underline",
-                      whiteSpace: "nowrap",
-                    }}
-                    className={"cursor-link"}
-                  >
-                    © {`${currentYear}`} Bahn zum Berg
-                  </Typography>
-                </a>
-              </Grid>
-              <Grid size="grow">
-                <Link
-                  to="/privacy"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ textDecoration: "none", color: "inherit" }}
+                  © {`${currentYear}`} Bahn zum Berg
+                </Typography>
+              </a>
+              <Link
+                to="/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "none", color: "inherit" }}
+              >
+                <Typography
+                  sx={{
+                    marginLeft: "10px",
+                    textDecoration: "underline",
+                    whiteSpace: "nowrap",
+                  }}
+                  className={"cursor-link"}
                 >
-                  <Typography
-                    sx={{
-                      marginLeft: "10px",
-                      textDecoration: "underline",
-                    }}
-                    className={"cursor-link"}
-                  >
-                    {t("start.datenschutz")}
-                  </Typography>
-                </Link>
-              </Grid>
-              <Grid size="grow">
-                <Link
-                  to="/imprint"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ textDecoration: "none", color: "inherit" }}
+                  {t("start.datenschutz")}
+                </Typography>
+              </Link>
+              <Link
+                to="/imprint"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "none", color: "inherit" }}
+              >
+                <Typography
+                  sx={{
+                    marginLeft: "10px",
+                    textDecoration: "underline",
+                    whiteSpace: "nowrap",
+                  }}
+                  className={"cursor-link"}
                 >
-                  <Typography
-                    sx={{
-                      marginLeft: "10px",
-                      textDecoration: "underline",
-                    }}
-                    className={"cursor-link"}
-                  >
-                    {t("start.impressum")}
-                  </Typography>
-                </Link>
-              </Grid>
-            </Grid>
+                  {t("start.impressum")}
+                </Typography>
+              </Link>
+            </Box>
           </Grid>
           <Grid
             size={{

--- a/src/components/InteractiveMap.tsx
+++ b/src/components/InteractiveMap.tsx
@@ -14,6 +14,7 @@ export interface InteractiveMapProps {
   anreiseGpxPositions: L.LatLngExpression[];
   abreiseGpxPositions: L.LatLngExpression[];
   scrollWheelZoom?: boolean;
+  hoveredStop?: { lat: number; lon: number } | null;
 }
 
 export default function InteractiveMap({
@@ -21,6 +22,7 @@ export default function InteractiveMap({
   anreiseGpxPositions,
   abreiseGpxPositions,
   scrollWheelZoom = false,
+  hoveredStop,
 }: InteractiveMapProps) {
   const [map, setMap] = useState<L.Map | null>(null);
   const [poly, setPoly] = useState<L.Polyline | null>(null);
@@ -36,6 +38,11 @@ export default function InteractiveMap({
     iconUrl: "https://cdn.zuugle.at/img/zielpunkt.svg",
     iconSize: [33, 45],
     iconAnchor: [16, 46],
+  });
+  const stopIcon = L.icon({
+    iconUrl: "https://cdn.zuugle.at/img/stopsign.png",
+    iconSize: [30, 30],
+    iconAnchor: [15, 15],
   });
 
   const StartMarker = ({ position }: { position: L.LatLngExpression }) => {
@@ -173,6 +180,12 @@ export default function InteractiveMap({
           />
         )}
         <ZoomControl position="bottomright" />
+        {hoveredStop && (
+          <Marker
+            position={[hoveredStop.lat, hoveredStop.lon]}
+            icon={stopIcon}
+          />
+        )}
       </MapContainer>
       {/* Fullscreen toggle button */}
       <button

--- a/src/components/Itinerary/Itinerary.tsx
+++ b/src/components/Itinerary/Itinerary.tsx
@@ -9,15 +9,16 @@ import ConnectionSearchForm from "../ConnectionSearch/ConnectionSearchForm";
 export interface ItineraryProps {
   tour?: Tour;
   tourId?: string;
+  onStopHover?: (coords: { lat: number; lon: number } | null) => void;
 }
-const Itinerary = ({ tour, tourId: _tourId }: ItineraryProps) => {
+const Itinerary = ({ tour, tourId: _tourId, onStopHover }: ItineraryProps) => {
   const city = useSelector((state: RootState) => state.search.city);
 
   return (
     <div className="tour-detail-itinerary-container">
       <div className="tour-detail-itinerary">
         {tour ? (
-          <ConnectionSearchForm tour={tour} />
+          <ConnectionSearchForm tour={tour} onStopHover={onStopHover} />
         ) : (
           <>
             <p className="tour-detail-itinerary-header">

--- a/src/hooks/useDianaAutocomplete.ts
+++ b/src/hooks/useDianaAutocomplete.ts
@@ -47,7 +47,7 @@ export function useDianaAutocomplete(lang: string) {
 
           const params = new URLSearchParams({
             q: query,
-            limit: "6",
+            limit: "5",
             lang: mapLanguage(lang),
           });
 

--- a/src/views/TourDetails.tsx
+++ b/src/views/TourDetails.tsx
@@ -5,7 +5,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Typography from "@mui/material/Typography";
 import DownloadIcon from "@mui/icons-material/Download";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useHead } from "@unhead/react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -34,6 +34,12 @@ import LanguageMenu from "../components/LanguageMenu";
 export default function DetailReworked() {
   const { cityOne } = useParams();
   const { idOne } = useParams();
+
+  // Hovered stop coordinates from the connection timeline
+  const [hoveredStop, setHoveredStop] = useState<{
+    lat: number;
+    lon: number;
+  } | null>(null);
 
   const { i18n } = useTranslation();
 
@@ -65,14 +71,6 @@ export default function DetailReworked() {
     dispatch(cityUpdated(resolved));
     dispatch(citySlugUpdated(resolved?.value ?? null));
   }, [allCities, areCitiesLoaded, cityOne, dispatch]);
-
-  // Prevent browser scroll restoration on page load/refresh
-  useEffect(() => {
-    if ("scrollRestoration" in window.history) {
-      window.history.scrollRestoration = "manual";
-    }
-    window.scrollTo(0, 0);
-  }, []);
 
   const providerUrl = () => {
     let url = tour?.url;
@@ -432,7 +430,11 @@ export default function DetailReworked() {
                   className="tour-detail-itinerary-container"
                   sx={{ flex: 1, minWidth: 0 }}
                 >
-                  <Itinerary tour={tour} tourId={idOne} />
+                  <Itinerary
+                    tour={tour}
+                    tourId={idOne}
+                    onStopHover={setHoveredStop}
+                  />
                 </Box>
               </Box>
 
@@ -441,14 +443,14 @@ export default function DetailReworked() {
                 sx={{
                   flex: { md: "1 1 50%" },
                   minHeight: { xs: "350px", md: "unset" },
-                  height: { md: "calc(100vh - 320px)" },
+                  height: { md: "calc(100vh - 80px)" },
                   order: { xs: 2, md: 2 },
                   display: "flex",
                   flexDirection: "column",
                   pt: { md: "20px" },
                   gap: "12px",
                   position: { md: "sticky" },
-                  top: { md: "16px" },
+                  top: { md: "72px" },
                   alignSelf: { md: "flex-start" },
                 }}
               >
@@ -468,11 +470,12 @@ export default function DetailReworked() {
                       anreiseGpxPositions={toTourTrack || []}
                       abreiseGpxPositions={fromTourTrack || []}
                       scrollWheelZoom={false}
+                      hoveredStop={hoveredStop}
                     />
                   </Box>
                 )}
                 {/* GPX Download + Share below the map */}
-                {city && idOne && actionButtonPart}
+                {idOne && actionButtonPart}
               </Box>
             </Box>
           </Box>


### PR DESCRIPTION
… markers, timeline spacing

- Fix sticky map to stay below header on desktop (top: 72px)
- Fix footer link overlap on mobile (flexbox wrap)
- Show GPX download button even without city selected
- Add stop-hover-to-map marker feature (stopsign.png)
- Thread onStopHover callback through component chain
- Left-align search button on mobile, fix focus color to violet
- Increase timeline spacing (mt/mb: 20px)
- Autocomplete: limit to 5 results, filter Alpine bounding box
- Add Valkey caching for autocomplete and connections endpoints