### PR TITLE
Add Bedarfsverkehr (on-demand transport) toggle on tour detail pages

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -284,6 +284,7 @@
     "startort_placeholder": "Adresse oder Haltestelle eingeben",
     "zielort": "Zielort",
     "aktivitaetsdatum": "Aktivitätsdatum",
+    "bedarfsverkehr": "Bedarfsverkehr",
     "heute": "Heute",
     "morgen": "Morgen",
     "anderes_datum": "Anderes Datum",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -284,6 +284,7 @@
     "startort_placeholder": "Enter address or station",
     "zielort": "Destination",
     "aktivitaetsdatum": "Activity date",
+    "bedarfsverkehr": "On-demand transport",
     "heute": "Today",
     "morgen": "Tomorrow",
     "anderes_datum": "Other date",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -284,6 +284,7 @@
     "startort_placeholder": "Saisir une adresse ou un arrêt",
     "zielort": "Destination",
     "aktivitaetsdatum": "Date de l'activité",
+    "bedarfsverkehr": "Transport à la demande",
     "heute": "Aujourd'hui",
     "morgen": "Demain",
     "anderes_datum": "Autre date",

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -283,6 +283,7 @@
     "startort_placeholder": "Inserisci indirizzo o fermata",
     "zielort": "Destinazione",
     "aktivitaetsdatum": "Data dell'attività",
+    "bedarfsverkehr": "Trasporto a chiamata",
     "heute": "Oggi",
     "morgen": "Domani",
     "anderes_datum": "Altra data",

--- a/public/i18n/sl.json
+++ b/public/i18n/sl.json
@@ -284,6 +284,7 @@
     "startort_placeholder": "Vnesite naslov ali postajo",
     "zielort": "Cilj",
     "aktivitaetsdatum": "Datum aktivnosti",
+    "bedarfsverkehr": "Prevoz na klic",
     "heute": "Danes",
     "morgen": "Jutri",
     "anderes_datum": "Drug datum",

--- a/src/components/ConnectionSearch/ConnectionResults.tsx
+++ b/src/components/ConnectionSearch/ConnectionResults.tsx
@@ -103,6 +103,7 @@ interface ConnectionResultsProps {
     fromEnd?: string;
   } | null;
   onStopHover?: (coords: { lat: number; lon: number } | null) => void;
+  useFlex?: boolean;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────
@@ -917,6 +918,7 @@ export default function ConnectionResults({
   activityDurationMinutes,
   shareTimeHints,
   onStopHover,
+  useFlex,
 }: ConnectionResultsProps) {
   const { t, i18n } = useTranslation();
   const { connections, activity } = data;
@@ -1080,7 +1082,7 @@ export default function ConnectionResults({
       });
 
       const { shareId } = await resp.json();
-      const shareUrl = `${window.location.origin}${window.location.pathname}?diana-share=${shareId}`;
+      const shareUrl = `${window.location.origin}${window.location.pathname}?diana-share=${shareId}${useFlex ? "&flex=1" : ""}`;
 
       // Use native Web Share API if available, otherwise copy to clipboard
       if (navigator.share) {

--- a/src/components/ConnectionSearch/ConnectionSearchForm.tsx
+++ b/src/components/ConnectionSearch/ConnectionSearchForm.tsx
@@ -6,6 +6,8 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
 import Autocomplete from "@mui/material/Autocomplete";
 import CircularProgress from "@mui/material/CircularProgress";
 import InputAdornment from "@mui/material/InputAdornment";
@@ -85,6 +87,7 @@ export default function ConnectionSearchForm({
   const [connectionsResult, setConnectionsResult] =
     useState<ConnectionsResultData | null>(null);
   const [searchError, setSearchError] = useState<string | null>(null);
+  const [useFlex, setUseFlex] = useState(false);
 
   // Share restore state
   const [searchParams] = useSearchParams();
@@ -136,7 +139,7 @@ export default function ConnectionSearchForm({
       activity_duration_minutes: String(activityDurationMinutes),
       date: selectedDate,
       lang: lang,
-      use_flex: "false",
+      use_flex: useFlex ? "true" : "false",
       timezone: "Europe/Vienna",
     });
 
@@ -179,7 +182,7 @@ export default function ConnectionSearchForm({
           activity_duration_minutes: String(activityDurationMinutes),
           date,
           lang: lang,
-          use_flex: "false",
+          use_flex: useFlex ? "true" : "false",
           timezone: "Europe/Vienna",
         });
 
@@ -211,6 +214,12 @@ export default function ConnectionSearchForm({
   useEffect(() => {
     if (!shareId || shareRestored.current) return;
     shareRestored.current = true;
+
+    // Restore flex toggle from share URL (?flex=1)
+    const flexParam = searchParams.get("flex");
+    if (flexParam === "1") {
+      setUseFlex(true);
+    }
 
     const restoreShare = async () => {
       try {
@@ -579,6 +588,34 @@ export default function ConnectionSearchForm({
                 </Button>
               </Box>
             </Box>
+
+            {/* Bedarfsverkehr toggle */}
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={useFlex}
+                  onChange={(e) => setUseFlex(e.target.checked)}
+                  size="small"
+                  sx={{
+                    "& .MuiSwitch-switchBase.Mui-checked": {
+                      color: "var(--bzb-akelei)",
+                    },
+                    "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                      backgroundColor: "var(--bzb-akelei)",
+                    },
+                  }}
+                />
+              }
+              label={t("details.bedarfsverkehr")}
+              sx={{
+                mt: "4px",
+                ml: 0,
+                "& .MuiFormControlLabel-label": {
+                  fontSize: "14px",
+                  color: "#555",
+                },
+              }}
+            />
           </>
         ) : (
           /* Multi-day tour: date pickers + button in same flex-wrap row */
@@ -685,6 +722,34 @@ export default function ConnectionSearchForm({
                 )}
               </Button>
             </Box>
+
+            {/* Bedarfsverkehr toggle */}
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={useFlex}
+                  onChange={(e) => setUseFlex(e.target.checked)}
+                  size="small"
+                  sx={{
+                    "& .MuiSwitch-switchBase.Mui-checked": {
+                      color: "var(--bzb-akelei)",
+                    },
+                    "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                      backgroundColor: "var(--bzb-akelei)",
+                    },
+                  }}
+                />
+              }
+              label={t("details.bedarfsverkehr")}
+              sx={{
+                mt: "4px",
+                ml: 0,
+                "& .MuiFormControlLabel-label": {
+                  fontSize: "14px",
+                  color: "#555",
+                },
+              }}
+            />
           </Box>
         )}
 
@@ -741,6 +806,7 @@ export default function ConnectionSearchForm({
             activityDurationMinutes={activityDurationMinutes}
             shareTimeHints={shareTimeHints}
             onStopHover={onStopHover}
+            useFlex={useFlex}
           />
         )}
       </Box>


### PR DESCRIPTION
- Add MUI Switch toggle below the activity date picker (default: off)
- Wire toggle to use_flex API parameter (true/false)
- Persist flex state in shared links via ?flex=1 URL param
- Add i18n translations for all 5 languages (de/en/fr/it/sl)