### PR TITLE
Fix link sharing: sync ?p= into filter.providers, redirect ?map=true …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { Routes, Route, Navigate } from "react-router";
+import { Routes, Route, Navigate, useSearchParams } from "react-router";
 import "./App.css";
 import StartSkeleton from "./views/Start/StartSkeleton";
 
@@ -33,6 +33,23 @@ function SimpleLoader() {
   );
 }
 
+/**
+ * Renders the start page, unless ?map=true is present.
+ * The hero image on "/" takes too much space for a useful map,
+ * so we redirect to /search where the map is properly displayed.
+ */
+function StartOrRedirectToSearch() {
+  const [params] = useSearchParams();
+  if (params.get("map") === "true") {
+    return <Navigate to={`/search?${params.toString()}`} replace />;
+  }
+  return (
+    <Suspense fallback={<StartSkeleton />}>
+      <ThemedApp routeKey="start" />
+    </Suspense>
+  );
+}
+
 function App() {
   return (
     <main
@@ -44,23 +61,9 @@ function App() {
       }}
     >
       <Routes>
-        {/* Start page with skeleton fallback */}
-        <Route
-          path="/"
-          element={
-            <Suspense fallback={<StartSkeleton />}>
-              <ThemedApp routeKey="start" />
-            </Suspense>
-          }
-        />
-        <Route
-          path="/total"
-          element={
-            <Suspense fallback={<StartSkeleton />}>
-              <ThemedApp routeKey="start" />
-            </Suspense>
-          }
-        />
+        {/* Start page — redirect to /search when ?map=true */}
+        <Route path="/" element={<StartOrRedirectToSearch />} />
+        <Route path="/total" element={<StartOrRedirectToSearch />} />
 
         {/* Other routes with simple loader */}
         <Route

--- a/src/components/SearchParamSync.ts
+++ b/src/components/SearchParamSync.ts
@@ -181,8 +181,14 @@ export default function SearchParamSync({
       syncCityFromLocalStorage();
     }
     updateReduxFromParam("p", providerUpdated);
+    const urlProvider = params.get("p");
+
     if (!isSearchResultsPage) {
       dispatch(searchWithTypeUpdated(null));
+      // Sync ?p= into filter.providers so chip + dialog checkbox reflect it
+      if (urlProvider) {
+        dispatch(filterUpdated({ providers: [urlProvider] }));
+      }
     } else {
       const searchPhrase = params.get("search");
       const rawSearchType = params.get("search_type");
@@ -238,6 +244,13 @@ export default function SearchParamSync({
       const range = params.get("range");
       if (range && !filterObject.ranges?.length) {
         filterObject.ranges = [range];
+      }
+      // Sync ?p= into filter.providers so chip + dialog checkbox reflect it
+      if (urlProvider && !filterObject.providers?.includes(urlProvider)) {
+        filterObject.providers = [
+          ...(filterObject.providers ?? []),
+          urlProvider,
+        ];
       }
       dispatch(filterUpdated(filterObject));
     }

--- a/src/components/SearchParamSync.ts
+++ b/src/components/SearchParamSync.ts
@@ -187,7 +187,7 @@ export default function SearchParamSync({
       dispatch(searchWithTypeUpdated(null));
       // Sync ?p= into filter.providers so chip + dialog checkbox reflect it
       if (urlProvider) {
-        dispatch(filterUpdated({ providers: [urlProvider] }));
+        dispatch(filterUpdated({ ...filter, providers: [urlProvider] }));
       }
     } else {
       const searchPhrase = params.get("search");
@@ -222,7 +222,7 @@ export default function SearchParamSync({
         dispatch(geolocationUpdated(null));
       }
 
-      const filterObject: FilterObject = {};
+      const filterObject: FilterObject = { ...filter };
       for (const key of SCALAR_FILTER_KEYS) {
         const value = params.get(key);
         if (value === "true") (filterObject[key] as boolean) = true;


### PR DESCRIPTION
…to /search

The ?p= URL parameter was only stored in search.provider (searchSlice) but never synced into filter.providers (filterSlice). This caused filter chips and the filter dialog checkbox to not reflect the active provider filter.

Additionally, opening / with ?map=true now redirects to /search preserving all query parameters, since the start page hero image leaves insufficient space for a useful map display.

Fixes #898