### PR TITLE
Add SRI integrity hash to Matomo script (#912)

### DIFF
--- a/src/ThemedApp.tsx
+++ b/src/ThemedApp.tsx
@@ -27,6 +27,10 @@ export default function ThemedApp({ routeKey }: ThemedAppProps) {
       s = d.getElementsByTagName("script")[0];
     g.defer = true;
     g.src = "https://stats.bahnzumberg.at/js/container_ANAXmMKf.js";
+    // #912 — SRI: update hash when Matomo container config changes
+    g.integrity =
+      "sha384-xq1s4f7tDrv3XAEX/mqNC4jnq/Wx7wyMD3qrENG/QKP9Fnx6BfKIfGVpi8APPRU6";
+    g.crossOrigin = "anonymous";
     s.parentNode?.insertBefore(g, s);
     _mtm.push({ language: i18next.resolvedLanguage });
   }, []);


### PR DESCRIPTION
## Änderungen

Fügt `integrity` (SHA-384) und `crossorigin="anonymous"` zum dynamisch geladenen Matomo Tag Manager Script hinzu.

**Warum:** Ohne SRI könnte bei einer Kompromittierung von `stats.bahnzumberg.at` beliebiger Code im Kontext von zuugle.at ausgeführt werden (Supply-Chain-Risiko).

**Wichtig:** Der Hash muss aktualisiert werden, wenn sich die Matomo-Container-Konfiguration ändert. Andernfalls wird das Script vom Browser blockiert (gewünschtes Sicherheitsverhalten).

Closes #912