### PR TITLE
Query params

### DIFF
--- a/apps/backend/src/routes/tours.js
+++ b/apps/backend/src/routes/tours.js
@@ -682,7 +682,6 @@ const getMatchingTourIds = async (req) => {
     const type = req.query.type;
     const domain = req.query.domain;
     const tld = get_domain_country(domain).toUpperCase();
-    const provider = req.query.provider;
     const language = req.query.language;
 
     let searchType = req.query["search_type"];
@@ -714,7 +713,6 @@ const getMatchingTourIds = async (req) => {
     let new_search_where_state = ``;
     let new_search_where_range = ``;
     let new_search_where_type = ``;
-    let new_search_where_provider = ``;
     let new_search_where_map = ``;
     let new_search_where_language = ``;
     let bindings = [];
@@ -969,11 +967,6 @@ const getMatchingTourIds = async (req) => {
         bindings.push(type);
     }
 
-    if (!!provider && provider.length > 0) {
-        new_search_where_provider = `AND t.provider=? `;
-        bindings.push(provider);
-    }
-
     if (!!language && language.length > 0) {
         new_search_where_language = `AND text_lang=?  `;
         bindings.push(language);
@@ -1007,7 +1000,6 @@ const getMatchingTourIds = async (req) => {
                                     ${new_search_where_range}
                                     ${new_search_where_state}
                                     ${new_search_where_type}
-                                    ${new_search_where_provider}
                                     ${new_search_where_language}
                                     ${new_search_where_map}
                                     ${new_filter_where_singleDayTour}

--- a/apps/frontend/src/components/Map/PopupCard.tsx
+++ b/apps/frontend/src/components/Map/PopupCard.tsx
@@ -9,20 +9,23 @@ import { Popup } from "react-leaflet";
 import L from "leaflet";
 import { Marker } from "../../models/mapTypes";
 import { t } from "i18next";
+import { useSelector } from "react-redux";
+import { RootState } from "../..";
 
 function PopupCard({
   tour,
   city,
-  provider,
   activeMarker,
   setActiveMarker,
 }: {
   tour: Tour | null;
   city: string;
-  provider: string | null;
   activeMarker: Marker | null;
   setActiveMarker: (marker: Marker | null) => void;
 }) {
+  const externalLinks = useSelector(
+    (state: RootState) => state.search.externalLinks,
+  );
   if (!activeMarker || !tour) return null;
   return (
     <Popup
@@ -57,7 +60,7 @@ function PopupCard({
           <div className="mt-1" style={{ marginBottom: "40px", width: "100%" }}>
             <Typography style={{ whiteSpace: "break-space", fontSize: "10px" }}>
               <a
-                href={getTourLink(tour, city, provider)}
+                href={getTourLink(tour, city, externalLinks)}
                 target="_blank"
                 rel="noopener"
                 className="updated-title curser-link"

--- a/apps/frontend/src/components/Map/TourMapContainer.tsx
+++ b/apps/frontend/src/components/Map/TourMapContainer.tsx
@@ -46,7 +46,6 @@ import ResizableCircle from "./ResizableCircle";
 import { MapClickHandler } from "./MapClickHandler";
 import { MapBoundsUpdater } from "./MapBoundsUpdater";
 import { MapBoundsSync } from "./MapBoundsSync";
-import { useSearchParams } from "react-router";
 import { renderToStaticMarkup } from "react-dom/server";
 import { suggestionIconMap } from "../Search/SearchSuggestions";
 import { theme } from "../../theme";
@@ -228,9 +227,6 @@ export default function TourMapContainer({
   const [markersInvalidated, setMarkersInvalidated] = useState(false);
   const [isUserMoving, setIsUserMoving] = useState(false);
   const dispatch = useAppDispatch();
-
-  const [searchParams] = useSearchParams();
-  const provider = searchParams.get("p");
 
   // --- Multi-track state ---
   const [allGpxTracks, setAllGpxTracks] = useState<
@@ -522,7 +518,6 @@ export default function TourMapContainer({
         <MemoizedPopupCard
           tour={selectedTour}
           city={city?.value || ""}
-          provider={provider}
           activeMarker={activeMarker}
           setActiveMarker={setActiveMarker}
         />

--- a/apps/frontend/src/components/Search/Search.tsx
+++ b/apps/frontend/src/components/Search/Search.tsx
@@ -13,6 +13,7 @@ import {
   searchWithTypeUpdated,
 } from "../../features/searchSlice";
 import { filterUpdated } from "../../features/filterSlice";
+import { writeFilterParams } from "../../utils/filterParams";
 import { useAppDispatch } from "../../hooks";
 import { useEffect, useState } from "react";
 import SearchButton from "./SearchButton";
@@ -26,7 +27,9 @@ export const emptySearch: SearchWithType = { term: "", type: "term" };
 export default function Search({ setFilterOn }: SearchProps) {
   const navigate = useNavigate();
   const filter = useSelector((state: RootState) => state.filter);
-  const provider = useSelector((state: RootState) => state.search.provider);
+  const externalLinks = useSelector(
+    (state: RootState) => state.search.externalLinks,
+  );
   const language = useSelector((state: RootState) => state.search.language);
   const city = useSelector((state: RootState) => state.search.city);
   const { data: allCities = [] } = useGetCitiesQuery();
@@ -86,8 +89,8 @@ export default function Search({ setFilterOn }: SearchProps) {
       }
     } else {
       const searchParams = new URLSearchParams();
-      if (provider) {
-        searchParams.set("p", provider);
+      if (externalLinks) {
+        searchParams.set("externalLinks", "true");
       }
       if (language) {
         searchParams.set("lang", language);
@@ -100,6 +103,9 @@ export default function Search({ setFilterOn }: SearchProps) {
         searchParams.set("search_type", search.type);
         searchParams.set("search", search.term);
       }
+      // Carry the active filters over so they survive the landing → /search
+      // navigation (they live in Redux but aren't in the landing page URL).
+      writeFilterParams(searchParams, filter);
       navigate(`/search?${searchParams.toString()}`);
     }
   };

--- a/apps/frontend/src/components/SearchParamSync.ts
+++ b/apps/frontend/src/components/SearchParamSync.ts
@@ -8,7 +8,7 @@ import {
   cityUpdated,
   mapUpdated,
   geolocationUpdated,
-  providerUpdated,
+  externalLinksUpdated,
   searchWithTypeUpdated,
 } from "../features/searchSlice";
 import {
@@ -19,32 +19,11 @@ import {
 import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
 import { filterUpdated } from "../features/filterSlice";
 import { FilterObject } from "../models/Filter";
-import { getDefaultFilterValues } from "./Filter/utils";
-
-const SCALAR_FILTER_KEYS = [
-  "singleDayTour",
-  "multipleDayTour",
-  "summerSeason",
-  "winterSeason",
-  "traverse",
-  "minAscent",
-  "maxAscent",
-  "minDescent",
-  "maxDescent",
-  "minTransportDuration",
-  "maxTransportDuration",
-  "minDistance",
-  "maxDistance",
-] as const;
-
-const ARRAY_FILTER_KEYS = [
-  "ranges",
-  "types",
-  "languages",
-  "difficulties",
-  "providers",
-  "countries",
-] as const;
+import {
+  ARRAY_FILTER_KEYS,
+  SCALAR_FILTER_KEYS,
+  writeFilterParams,
+} from "../utils/filterParams";
 
 /**
  * Keeps query parameters in sync with the Redux store.
@@ -100,7 +79,11 @@ export default function SearchParamSync({
     // use Redux value when available, fall back to URL during initialisation (when language is null)
     updateParam(newParams, "lang", search.language ?? params.get("lang"));
     updateParam(newParams, "city", search.citySlug);
-    updateParam(newParams, "p", search.provider);
+    updateParam(
+      newParams,
+      "externalLinks",
+      search.externalLinks ? "true" : null,
+    );
     updateParam(
       newParams,
       "map",
@@ -131,19 +114,7 @@ export default function SearchParamSync({
     }
 
     if (isSearchResultsPage) {
-      const defaults = getDefaultFilterValues();
-      for (const key of SCALAR_FILTER_KEYS) {
-        const val = filter[key];
-        if (val !== undefined && val !== defaults[key]) {
-          newParams.set(key, String(val));
-        }
-      }
-      for (const key of ARRAY_FILTER_KEYS) {
-        const arr = filter[key];
-        if (arr?.length) {
-          newParams.set(key, arr.map(String).join("|"));
-        }
-      }
+      writeFilterParams(newParams, filter);
     }
     setParams(newParams, { replace: true });
   }, [search, filter]);
@@ -180,14 +151,31 @@ export default function SearchParamSync({
       // No ?city= in URL — use localStorage as fallback
       syncCityFromLocalStorage();
     }
-    updateReduxFromParam("p", providerUpdated);
-    const urlProvider = params.get("p");
+
+    // Legacy ?p= embedded-provider param. It is folded into the providers filter
+    // (single source of truth) below and dropped from the URL by the Redux → URL
+    // sync above, so ?p=X is effectively rewritten to ?providers=X. The
+    // bahn-zum-berg embed additionally enables external tour links.
+    const legacyProvider = params.get("p");
+    dispatch(
+      externalLinksUpdated(
+        params.get("externalLinks") === "true" ||
+          legacyProvider === "bahnzumberg",
+      ),
+    );
 
     if (!isSearchResultsPage) {
       dispatch(searchWithTypeUpdated(null));
       // Sync ?p= into filter.providers so chip + dialog checkbox reflect it
-      if (urlProvider) {
-        dispatch(filterUpdated({ ...filter, providers: [urlProvider] }));
+      if (legacyProvider) {
+        dispatch(
+          filterUpdated({
+            ...filter,
+            providers: filter.providers?.includes(legacyProvider)
+              ? filter.providers
+              : [...(filter.providers ?? []), legacyProvider],
+          }),
+        );
       }
     } else {
       const searchPhrase = params.get("search");
@@ -246,11 +234,12 @@ export default function SearchParamSync({
         filterObject.ranges = [range];
       }
       // Sync ?p= into filter.providers so chip + dialog checkbox reflect it
-      if (urlProvider && !filterObject.providers?.includes(urlProvider)) {
-        filterObject.providers = [
-          ...(filterObject.providers ?? []),
-          urlProvider,
-        ];
+      if (legacyProvider) {
+        filterObject.providers = filterObject.providers?.includes(
+          legacyProvider,
+        )
+          ? filterObject.providers
+          : [...(filterObject.providers ?? []), legacyProvider];
       }
       dispatch(filterUpdated(filterObject));
     }

--- a/apps/frontend/src/components/StartTourCardContainer.tsx
+++ b/apps/frontend/src/components/StartTourCardContainer.tsx
@@ -61,14 +61,12 @@ export interface StartTourCardContainerProps {
   tours: Tour[];
   city: string;
   isLoading: boolean;
-  provider: string | null;
 }
 
 export default function StartTourCardContainer({
   tours,
   city,
   isLoading,
-  provider,
 }: StartTourCardContainerProps) {
   const { t } = useTranslation();
 
@@ -94,7 +92,7 @@ export default function StartTourCardContainer({
           >
             {displayTours.map((tour, index) => (
               <Box key={index} sx={{ display: "flex", minWidth: 0 }}>
-                <TourCard tour={tour} city={city} provider={provider} />
+                <TourCard tour={tour} city={city} />
               </Box>
             ))}
           </Box>

--- a/apps/frontend/src/components/TourCard.tsx
+++ b/apps/frontend/src/components/TourCard.tsx
@@ -11,16 +11,20 @@ import { Tour } from "../models/Tour";
 import Link from "@mui/material/Link";
 import Chip from "@mui/material/Chip";
 import StarRoundedIcon from "@mui/icons-material/StarRounded";
+import { useSelector } from "react-redux";
+import { RootState } from "..";
 
 const DEFAULT_IMAGE = "https://cdn.zuugle.at/img/dummy.webp";
 
 export interface TourCardProps {
   tour: Tour;
   city: string | null;
-  provider: string | null;
 }
 
-export default function TourCard({ tour, city, provider }: TourCardProps) {
+export default function TourCard({ tour, city }: TourCardProps) {
+  const externalLinks = useSelector(
+    (state: RootState) => state.search.externalLinks,
+  );
   const [image, setImage] = useState(DEFAULT_IMAGE);
 
   // i18next
@@ -40,7 +44,7 @@ export default function TourCard({ tour, city, provider }: TourCardProps) {
     }
   }, [tour]);
 
-  const tourLink = getTourLink(tour, city, provider);
+  const tourLink = getTourLink(tour, city, externalLinks);
 
   const anreisedauer_notlong = t("details.anreisedauer").length < 100;
   const umstiege_notlong = t("start.umstiege").length < 100;

--- a/apps/frontend/src/components/TourCardContainer.tsx
+++ b/apps/frontend/src/components/TourCardContainer.tsx
@@ -22,7 +22,6 @@ export default function TourCardContainer({
   fetchMore,
 }: TourCardContainerProps) {
   const city = useSelector((state: RootState) => state.search.city);
-  const provider = useSelector((state: RootState) => state.search.provider);
   const LOADER_HEIGHT = 40;
 
   useEffect(() => {
@@ -59,11 +58,7 @@ export default function TourCardContainer({
       >
         {tours.map((tour, index) => (
           <Box key={index} sx={{ display: "flex", minWidth: 0 }}>
-            <TourCard
-              tour={tour}
-              city={city?.value || null}
-              provider={provider}
-            />
+            <TourCard tour={tour} city={city?.value || null} />
           </Box>
         ))}
       </Box>

--- a/apps/frontend/src/features/apiSlice.ts
+++ b/apps/frontend/src/features/apiSlice.ts
@@ -72,7 +72,6 @@ export interface ToursParams {
   limit?: number;
   city: string;
   ranges?: boolean;
-  provider?: string;
   filter?: FilterObject;
   search?: string;
   search_type?: string;

--- a/apps/frontend/src/features/searchSlice.ts
+++ b/apps/frontend/src/features/searchSlice.ts
@@ -28,7 +28,12 @@ export interface SearchState {
   language: string | null;
   map: boolean;
   bounds: BoundsObject | null;
-  provider: string | null;
+  /**
+   * When true, tour links point directly to the provider's own website
+   * (e.g. bahn-zum-berg.at) instead of our internal /tour/ detail pages.
+   * Driven by the ?externalLinks= URL param (and the legacy ?p= param).
+   */
+  externalLinks: boolean;
   geolocation: LocationWithRadius | null;
 }
 
@@ -39,7 +44,7 @@ const initialState: SearchState = {
   language: null,
   map: false,
   bounds: null,
-  provider: null,
+  externalLinks: false,
   geolocation: null,
 };
 
@@ -68,8 +73,8 @@ const searchSlice = createSlice({
     mapUpdated: (state, action: PayloadAction<boolean>) => {
       state.map = action.payload;
     },
-    providerUpdated: (state, action: PayloadAction<string | null>) => {
-      state.provider = action.payload;
+    externalLinksUpdated: (state, action: PayloadAction<boolean>) => {
+      state.externalLinks = action.payload;
     },
     geolocationUpdated: (
       state,
@@ -87,7 +92,7 @@ export const {
   languageUpdated,
   boundsUpdated,
   mapUpdated,
-  providerUpdated,
+  externalLinksUpdated,
   geolocationUpdated,
 } = searchSlice.actions;
 export default searchSlice.reducer;

--- a/apps/frontend/src/hooks/useSearchTours.ts
+++ b/apps/frontend/src/hooks/useSearchTours.ts
@@ -82,7 +82,6 @@ export function useSearchTours() {
       search_type: search.searchWithType?.type || null,
       bounds: search.bounds || undefined,
       map: showMap || undefined,
-      provider: search.provider || undefined,
       currLanguage: search.language || undefined,
       geolocation: search.geolocation || undefined,
     };
@@ -110,7 +109,6 @@ export function useSearchTours() {
         search_type: search.searchWithType?.type || "",
         bounds: search.bounds || undefined,
         map: showMap || undefined,
-        provider: search.provider || undefined,
         page: pageTours,
         currLanguage: search.language || undefined,
         geolocation: search.geolocation || undefined,

--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -49,7 +49,10 @@ function getPreloadedSearchState() {
     citySlug: params.get("city") ?? cityObject?.value ?? null,
     map: params.get("map") === "true",
     language: params.get("lang") ?? null,
-    provider: params.get("p") ?? null,
+    // ?p=bahnzumberg is the legacy embed param; it enables external tour links.
+    externalLinks:
+      params.get("externalLinks") === "true" ||
+      params.get("p") === "bahnzumberg",
     range: params.get("range") ?? null,
     bounds: null,
     geolocation: null,

--- a/apps/frontend/src/utils/filterParams.ts
+++ b/apps/frontend/src/utils/filterParams.ts
@@ -1,0 +1,56 @@
+import { FilterObject } from "../models/Filter";
+import { getDefaultFilterValues } from "../components/Filter/utils";
+
+export const SCALAR_FILTER_KEYS = [
+  "singleDayTour",
+  "multipleDayTour",
+  "summerSeason",
+  "winterSeason",
+  "traverse",
+  "minAscent",
+  "maxAscent",
+  "minDescent",
+  "maxDescent",
+  "minTransportDuration",
+  "maxTransportDuration",
+  "minDistance",
+  "maxDistance",
+] as const;
+
+export const ARRAY_FILTER_KEYS = [
+  "ranges",
+  "types",
+  "languages",
+  "difficulties",
+  "providers",
+  "countries",
+] as const;
+
+/**
+ * Serialize the active (non-default) filter values into URL query params.
+ * Values equal to the defaults are removed so the URL stays clean.
+ * Shared by SearchParamSync (Redux → URL) and the landing → /search
+ * navigation so filters survive the transition.
+ */
+export function writeFilterParams(
+  params: URLSearchParams,
+  filter: FilterObject,
+) {
+  const defaults = getDefaultFilterValues();
+  for (const key of SCALAR_FILTER_KEYS) {
+    const val = filter[key];
+    if (val !== undefined && val !== defaults[key]) {
+      params.set(key, String(val));
+    } else {
+      params.delete(key);
+    }
+  }
+  for (const key of ARRAY_FILTER_KEYS) {
+    const arr = filter[key];
+    if (arr?.length) {
+      params.set(key, arr.map(String).join("|"));
+    } else {
+      params.delete(key);
+    }
+  }
+}

--- a/apps/frontend/src/utils/globals.tsx
+++ b/apps/frontend/src/utils/globals.tsx
@@ -16,16 +16,16 @@ function rewriteBahnZumBergDomain(url: string): string {
 export function getTourLink(
   tour: Tour,
   city: string | null,
-  provider: string | null,
+  externalLinks: boolean,
 ) {
   if (city && city !== "no-city") {
-    if (provider === "bahnzumberg") {
+    if (externalLinks) {
       return `${rewriteBahnZumBergDomain(tour.url)}ab-${city}/`;
     } else {
       return `/tour/${tour.id}/${city}`;
     }
   } else {
-    if (provider === "bahnzumberg") {
+    if (externalLinks) {
       return `${rewriteBahnZumBergDomain(tour.url)}`;
     } else {
       return `/tour/${tour.id}/no-city`;

--- a/apps/frontend/src/views/TourDetails.tsx
+++ b/apps/frontend/src/views/TourDetails.tsx
@@ -100,7 +100,6 @@ export default function DetailReworked() {
   const { data: allCities = [], isSuccess: areCitiesLoaded } =
     useGetCitiesQuery();
   const city = useSelector((state: RootState) => state.search.city);
-  const provider = useSelector((state: RootState) => state.search.provider);
 
   const [
     triggerLoadTours,
@@ -463,11 +462,7 @@ export default function DetailReworked() {
               >
                 {(suggestedTours?.tours ?? []).slice(0, 3).map((st, i) => (
                   <Box key={i} sx={{ display: "flex", minWidth: 0 }}>
-                    <TourCard
-                      tour={st}
-                      city={city?.value ?? ""}
-                      provider={provider}
-                    />
+                    <TourCard tour={st} city={city?.value ?? ""} />
                   </Box>
                 ))}
               </Box>


### PR DESCRIPTION
Legacy ?p= is folded into filter.providers and `externalLinks` drives behavior that click on a tour card directly opens the provider's tour page.
Fixes #898 and #936